### PR TITLE
Update to use setup-python action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install System Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pip python3.8-venv libcurl4-openssl-dev
+      - uses: actions/setup-python@v4 
+        with:
+          python-version: '3.9'
 
       - name: Install Schematic
         shell: bash


### PR DESCRIPTION
- address issue taken place in https://github.com/ncihtan/data-models/pull/86 with below error:
```
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```
Replace system dependencies step by  `setup-python@v4`.