### PR TITLE
Change Family History to list like to avoid comma-separated error dur…

### DIFF
--- a/example.model.csv
+++ b/example.model.csv
@@ -6,7 +6,7 @@ Year of Birth,,,,,FALSE,DataProperty,,,
 Diagnosis,,"Healthy, Cancer",,,TRUE,DataProperty,,,
 Cancer,,,"Cancer Type, Family History",,FALSE,ValidValue,,,
 Cancer Type,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,
-Family History,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,list
+Family History,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,list like
 Biospecimen,,,"Sample ID, Patient ID, Tissue Status, Component",,FALSE,DataType,Patient,,
 Sample ID,,,,,TRUE,DataProperty,,,
 Tissue Status,,"Healthy, Malignant",,,TRUE,DataProperty,,,

--- a/example.model.csv
+++ b/example.model.csv
@@ -6,7 +6,7 @@ Year of Birth,,,,,FALSE,DataProperty,,,
 Diagnosis,,"Healthy, Cancer",,,TRUE,DataProperty,,,
 Cancer,,,"Cancer Type, Family History",,FALSE,ValidValue,,,
 Cancer Type,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,
-Family History,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,list like
+Family History,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,list strict
 Biospecimen,,,"Sample ID, Patient ID, Tissue Status, Component",,FALSE,DataType,Patient,,
 Sample ID,,,,,TRUE,DataProperty,,,
 Tissue Status,,"Healthy, Malignant",,,TRUE,DataProperty,,,

--- a/example.model.jsonld
+++ b/example.model.jsonld
@@ -2185,7 +2185,7 @@
             "sms:displayName": "Family History",
             "sms:required": "sms:true",
             "sms:validationRules": [
-                "list like"
+                "list strict"
             ]
         },
         {

--- a/example.model.jsonld
+++ b/example.model.jsonld
@@ -2185,7 +2185,7 @@
             "sms:displayName": "Family History",
             "sms:required": "sms:true",
             "sms:validationRules": [
-                "list"
+                "list like"
             ]
         },
         {


### PR DESCRIPTION
…ing validation.

In previous versions of schematic, having only one value for Family History triggers an error 
```For attribute Family History in row 2 it does not appear as if you provided a comma delimited string. Please check your entry ('Breast'') and try again.
[['2', 'Family History', "For attribute Family History in row 2 it does not appear as if you provided a comma delimited string. Please check your entry ('Breast'') and try again.", 'Breast']]```

Changing the validation rule to list like allows entries to contain a single item or a comma-delimited string.

