### PR TITLE
Make mock attributes required, bring model up to parity with develop

### DIFF
--- a/example.model.csv
+++ b/example.model.csv
@@ -19,20 +19,20 @@ CSV/TSV,,,Genome Build,,FALSE,ValidValue,,,
 Genome Build,,"GRCh37, GRCh38, GRCm38, GRCm39",,,TRUE,DataProperty,,,
 Genome FASTA,,,,,TRUE,DataProperty,,,
 MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range",,FALSE,DataType,,,
-Check List,,"ab, cd, ef, gh",,,FALSE,DataProperty,,,list strict
-Check Regex List,,,,,FALSE,DataProperty,,,list strict::regex match [a-f]
-Check Regex Single,,,,,FALSE,DataProperty,,,regex search [a-f]
-Check Regex Format,,,,,FALSE,DataProperty,,,regex match [a-f]
-Check Num,,,,,FALSE,DataProperty,,,num
-Check Float,,,,,FALSE,DataProperty,,,float
-Check Int,,,,,FALSE,DataProperty,,,int
-Check String,,,,,FALSE,DataProperty,,,str
-Check URL,,,,,FALSE,DataProperty,,,url
-Check Match at Least,,,,,FALSE,DataProperty,,,matchAtLeastOne Patient.PatientID set
-Check Match Exactly,,,,,FALSE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactly set
-Check Match at Least values,,,,,FALSE,DataProperty,,,matchAtLeastOne MockComponent.checkMatchatLeastvalues value
-Check Match Exactly values,,,,,FALSE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactlyvalues value
+Check List,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list strict 
+Check Regex List,,,,,TRUE,DataProperty,,,list strict::regex match [a-f]
+Check Regex Single,,,,,TRUE,DataProperty,,,regex search [a-f]
+Check Regex Format,,,,,TRUE,DataProperty,,,regex match [a-f]
+Check Num,,,,,TRUE,DataProperty,,,num
+Check Float,,,,,TRUE,DataProperty,,,float
+Check Int,,,,,TRUE,DataProperty,,,int
+Check String,,,,,TRUE,DataProperty,,,str
+Check URL,,,,,TRUE,DataProperty,,,url
+Check Match at Least,,,,,TRUE,DataProperty,,,matchAtLeastOne Patient.PatientID set
+Check Match Exactly,,,,,TRUE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactly set
+Check Match at Least values,,,,,TRUE,DataProperty,,,matchAtLeastOne MockComponent.checkMatchatLeastvalues value
+Check Match Exactly values,,,,,TRUE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactlyvalues value
 Check Recommended,,,,,FALSE,DataProperty,,,recommended
-Check Ages,,,,,FALSE,DataProperty,,,protectAges
-Check Unique,,,,,FALSE,DataProperty,,,unique error
-Check Range,,,,,FALSE,DataProperty,,,inRange 50 100 error
+Check Ages,,,,,TRUE,DataProperty,,,protectAges
+Check Unique,,,,,TRUE,DataProperty,,,unique error
+Check Range,,,,,TRUE,DataProperty,,,inRange 50 100 error

--- a/example.model.csv
+++ b/example.model.csv
@@ -18,7 +18,7 @@ CRAM,,,"Genome Build, Genome FASTA",,FALSE,ValidValue,,,
 CSV/TSV,,,Genome Build,,FALSE,ValidValue,,,
 Genome Build,,"GRCh37, GRCh38, GRCm38, GRCm39",,,TRUE,DataProperty,,,
 Genome FASTA,,,,,TRUE,DataProperty,,,
-MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range",,FALSE,DataType,,,
+MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range",,FALSE,DataType,Patient,,
 Check List,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list strict 
 Check Regex List,,,,,TRUE,DataProperty,,,list strict::regex match [a-f]
 Check Regex Single,,,,,TRUE,DataProperty,,,regex search [a-f]
@@ -36,4 +36,3 @@ Check Recommended,,,,,FALSE,DataProperty,,,recommended
 Check Ages,,,,,TRUE,DataProperty,,,protectAges
 Check Unique,,,,,TRUE,DataProperty,,,unique error
 Check Range,,,,,TRUE,DataProperty,,,inRange 50 100 error
-

--- a/example.model.jsonld
+++ b/example.model.jsonld
@@ -2568,7 +2568,7 @@
                 }
             ],
             "sms:displayName": "Check List",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "list strict"
             ]
@@ -2587,7 +2587,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Regex List",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "list strict",
                 "regex match [a-f]"
@@ -2607,7 +2607,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Regex Single",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "regex search [a-f]"
             ]
@@ -2626,7 +2626,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Regex Format",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "regex match [a-f]"
             ]
@@ -2645,7 +2645,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Num",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "num"
             ]
@@ -2664,7 +2664,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Float",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "float"
             ]
@@ -2683,7 +2683,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Int",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "int"
             ]
@@ -2702,7 +2702,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check String",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "str"
             ]
@@ -2721,7 +2721,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check URL",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "url"
             ]
@@ -2740,7 +2740,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Match at Least",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "matchAtLeastOne Patient.PatientID set"
             ]
@@ -2759,7 +2759,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Match Exactly",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "matchExactlyOne MockComponent.checkMatchExactly set"
             ]
@@ -2778,7 +2778,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Match at Least values",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "matchAtLeastOne MockComponent.checkMatchatLeastvalues value"
             ]
@@ -2797,7 +2797,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Match Exactly values",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "matchExactlyOne MockComponent.checkMatchExactlyvalues value"
             ]
@@ -2835,7 +2835,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Ages",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "protectAges"
             ]
@@ -2854,7 +2854,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Unique",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "unique error"
             ]
@@ -2873,7 +2873,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Range",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "inRange 50 100 error"
             ]

--- a/example.model.jsonld
+++ b/example.model.jsonld
@@ -2482,11 +2482,6 @@
             },
             "sms:displayName": "MockComponent",
             "sms:required": "sms:false",
-            "sms:requiresComponent": [
-                {
-                    "@id": "bts:Patient"
-                }
-            ],
             "sms:requiresDependency": [
                 {
                     "@id": "bts:Component"


### PR DESCRIPTION
Invalid entries for unrequired attributes now show as warnings. This PR brings the data model example into congruence with what's on develop and makes the `MockComponent` attributes required, with the exception of `Check Recommended`