### PR TITLE
Add workflow dispatch to data_curator_config

### DIFF
--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Repo dispatch to data_curator_config event generate-templates
         run: |
           curl -X POST \
-          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Authorization: token ${{ secrets.PAT_GITHUB }}" \
           -H "Accept: application/vnd.github+json" \
           https://api.github.com/repos/Sage-Bionetworks/data_curator_config/dispatches \
           -d '{"event_type": "generate_templates", "client_payload": { "commit_sha": "'${{ github.sha }}'",  "client_repo": "'${{ github.repository }}'"}'

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   repo_dispatch:
     # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
-    if: ${{ github.event.pull_request.merged == true || github.event != "pull_request" }}
+    if: github.event.pull_request.merged == true || github.event != "pull_request"
     runs-on: ubuntu-latest
     steps:
       - name: Repo dispatch to data_curator_config event generate-templates

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -31,12 +31,12 @@ on:
     # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
     if_merged:
       if: github.event.pull_request.merged == true
-        runs-on: ubuntu-latest
-        steps:
-          - name: Repo dispatch to data_curator_config event generate-templates
-            run: |
-              curl -X POST \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -H "Accept: application/vnd.github+json" \
-              https://api.github.com/repos/Sage-Bionetworks/data_curator_config/dispatches \
-              -d '{"event_type": "generate_templates", "client_payload": { "commit_sha": "'${{ github.sha }}'",  "client_repo": "'${{ github.repository }}'"}'
+      runs-on: ubuntu-latest
+      steps:
+        - name: Repo dispatch to data_curator_config event generate-templates
+          run: |
+            curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/Sage-Bionetworks/data_curator_config/dispatches \
+            -d '{"event_type": "generate_templates", "client_payload": { "commit_sha": "'${{ github.sha }}'",  "client_repo": "'${{ github.repository }}'"}'

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -28,9 +28,9 @@ concurrency:
   cancel-in-progress: true
   
 jobs:
-  # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
-  if_merged:
-    if: github.event.pull_request.merged == true
+  repo_dispatch:
+    # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
+    if: ${{ github.event.pull_request.merged == true || github.event != "pull_request" }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo dispatch to data_curator_config event generate-templates

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -31,7 +31,7 @@ jobs:
   echo:
     runs-on: ubuntu-latest
     steps:
-      run: echo ${{github.event}}
+      - run: echo ${{github.event}}
   repo_dispatch:
     # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
     if: github.event.pull_request.merged == true || github.event != 'pull_request'

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   repo_dispatch:
     # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
-    if: github.event.pull_request.merged == true || github.event != "pull_request"
+    if: github.event.pull_request.merged == true || github.event != pull_request
     runs-on: ubuntu-latest
     steps:
       - name: Repo dispatch to data_curator_config event generate-templates

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -15,28 +15,28 @@ on:
       - closed # requires if_merged job below to run only during a merged PR
   workflow_dispatch:
 
-  concurrency:
-  # cancel the current running workflow from the same branch, PR when a new workflow is triggered 
-  # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
-  # {{ github.workflow }}: the workflow name is used to generate the concurrency group. This allows you to have more than one workflows
-  # {{ github.ref_type }}: the type of Git ref object created in the repository. Can be either branch or tag 
-  # {{ github.sha }}: full commit sha 
-  # credit: https://github.com/Sage-Bionetworks-Workflows/sagetasks/blob/main/.github/workflows/ci.yml
+concurrency:
+# cancel the current running workflow from the same branch, PR when a new workflow is triggered 
+# when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
+# {{ github.workflow }}: the workflow name is used to generate the concurrency group. This allows you to have more than one workflows
+# {{ github.ref_type }}: the type of Git ref object created in the repository. Can be either branch or tag 
+# {{ github.sha }}: full commit sha 
+# credit: https://github.com/Sage-Bionetworks-Workflows/sagetasks/blob/main/.github/workflows/ci.yml
   group: >-
     ${{ github.workflow }}-${{ github.ref_type }}-
     ${{ github.sha }}
   cancel-in-progress: true
   
-  jobs:
-    # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
-    if_merged:
-      if: github.event.pull_request.merged == true
-      runs-on: ubuntu-latest
-      steps:
-        - name: Repo dispatch to data_curator_config event generate-templates
-          run: |
-            curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/Sage-Bionetworks/data_curator_config/dispatches \
-            -d '{"event_type": "generate_templates", "client_payload": { "commit_sha": "'${{ github.sha }}'",  "client_repo": "'${{ github.repository }}'"}'
+jobs:
+  # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repo dispatch to data_curator_config event generate-templates
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/Sage-Bionetworks/data_curator_config/dispatches \
+          -d '{"event_type": "generate_templates", "client_payload": { "commit_sha": "'${{ github.sha }}'",  "client_repo": "'${{ github.repository }}'"}'

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -28,9 +28,13 @@ concurrency:
   cancel-in-progress: true
   
 jobs:
+  echo:
+    runs-on: ubuntu-latest
+    steps:
+      run: echo ${{github.event}}
   repo_dispatch:
     # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
-    if: github.event.pull_request.merged == true || github.event != pull_request
+    if: github.event.pull_request.merged == true || github.event != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Repo dispatch to data_curator_config event generate-templates

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -15,6 +15,8 @@ on:
       - closed # requires if_merged job below to run only during a merged PR
   workflow_dispatch:
 
+permissions: write-all
+
 concurrency:
 # cancel the current running workflow from the same branch, PR when a new workflow is triggered 
 # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
@@ -28,7 +30,6 @@ concurrency:
   cancel-in-progress: true
   
 jobs:
-  permissions: write-all
   repo_dispatch:
     # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
     if: github.event.pull_request.merged == true || github.event != 'pull_request'

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -28,10 +28,7 @@ concurrency:
   cancel-in-progress: true
   
 jobs:
-  echo:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ${{github.event}}
+  permissions: write-all
   repo_dispatch:
     # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
     if: github.event.pull_request.merged == true || github.event != 'pull_request'

--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------------------------
+# When the main branch is updated, trigger a workflow in sage-bionetworks/data_curator_config
+# to generate templates from the data modell in this repo.
+# ------------------------------------------------------------------------------
+
+name: dcc_config_repo_dispatch
+# Can specify other branches or triggers for this workflow
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - closed # requires if_merged job below to run only during a merged PR
+  workflow_dispatch:
+
+  concurrency:
+  # cancel the current running workflow from the same branch, PR when a new workflow is triggered 
+  # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
+  # {{ github.workflow }}: the workflow name is used to generate the concurrency group. This allows you to have more than one workflows
+  # {{ github.ref_type }}: the type of Git ref object created in the repository. Can be either branch or tag 
+  # {{ github.sha }}: full commit sha 
+  # credit: https://github.com/Sage-Bionetworks-Workflows/sagetasks/blob/main/.github/workflows/ci.yml
+  group: >-
+    ${{ github.workflow }}-${{ github.ref_type }}-
+    ${{ github.sha }}
+  cancel-in-progress: true
+  
+  jobs:
+    # Extra logic to check PR is merged, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
+    if_merged:
+      if: github.event.pull_request.merged == true
+        runs-on: ubuntu-latest
+        steps:
+          - name: Repo dispatch to data_curator_config event generate-templates
+            run: |
+              curl -X POST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/Sage-Bionetworks/data_curator_config/dispatches \
+              -d '{"event_type": "generate_templates", "client_payload": { "commit_sha": "'${{ github.sha }}'",  "client_repo": "'${{ github.repository }}'"}'


### PR DESCRIPTION
Add a github workflow that will trigger the `generate_templates` workflow in [data_curator_config](https://github.com/Sage-Bionetworks/data_curator_config). This works on a push to main, merged PR to main, or manual trigger.