### PR TITLE
rename template_dir to community_dir

### DIFF
--- a/.github/workflows/dcc_config_repo_dispatch.yml
+++ b/.github/workflows/dcc_config_repo_dispatch.yml
@@ -24,7 +24,7 @@ env:
   DATA_MODEL: https://raw.githubusercontent.com/Sage-Bionetworks/data-models/main/example.model.jsonld
   # Can be NULL to generate templates for all schemas. Or a space-delimited string of schemas
   DATA_TYPES: "Biospecimen BulkRNA-seqAssay Patient"
-  TEMPLATE_DIR: demo/templates
+  COMMUNITY_DIR: demo
 
 concurrency:
 # cancel the current running workflow from the same branch, PR when a new workflow is triggered 
@@ -50,4 +50,4 @@ jobs:
           -H "Authorization: token ${{ secrets.PAT_GITHUB }}" \
           -H "Accept: application/vnd.github+json" \
           https://api.github.com/repos/Sage-Bionetworks/data_curator_config/dispatches \
-          -d '{"event_type": "generate_templates", "client_payload": { "data_model": "${{ env.DATA_MODEL }}",  "data_types": "${{ env.DATA_TYPES }}", "template_dir": "${{ env.TEMPLATE_DIR }}"}}'
+          -d '{"event_type": "generate_templates", "client_payload": { "data_model": "${{ env.DATA_MODEL }}",  "data_types": "${{ env.DATA_TYPES }}", "community_dir": "${{ env.COMMUNITY_DIR }}"}}'


### PR DESCRIPTION
use community_dir because other files besides templates, such as config.json aka dca-template-config.json can be added there.